### PR TITLE
TAG0.LOCKTYPE substitui o TDATA3

### DIFF
--- a/sphere_56b/trunk/scripts/myt/sistema_de_chaveiro.scp
+++ b/sphere_56b/trunk/scripts/myt/sistema_de_chaveiro.scp
@@ -541,7 +541,7 @@ elif (<src.targ.type>==t_door) || (<src.targ.type>==t_container) || (<src.targ.t
         return 1
     else
         if <more1>==<def.FECHADURA_CADEADO> 
-            if (<src.targ.type>==t_container) && ( (<src.targ.TDATA3> < 9) || (<src.targ.TDATA3> > 50) )
+            if (<src.targ.type>==t_container) && ( (<src.targ.TAG0.LOCKTYPE> < 9) || (<src.targ.TAG0.LOCKTYPE> > 50) )
                 src.sysmessagered Nao e possivel trancar isto com cadeado.
                 return 1
             endif
@@ -561,7 +561,7 @@ elif (<src.targ.type>==t_door) || (<src.targ.type>==t_container) || (<src.targ.t
             src.targ.tag.fechadura=<more1>
             
         else
-            if (<src.targ.type>==t_container) && ( (<src.targ.TDATA3> < 9) || (<src.targ.TDATA3> > 50) )
+            if (<src.targ.type>==t_container) && ( (<src.targ.TAG0.LOCKTYPE> < 9) || (<src.targ.TAG0.LOCKTYPE> > 50) )
                 src.sysmessagered Nao e possivel instalar uma fechadura neste local.
                 return 1
             endif


### PR DESCRIPTION
Também foi atualizado nos containers de tailor, tinker, blacksmith e carpintery (trocado o TDATA3 por TAG.LOCKTYPE)