### PR TITLE
Correções de Returns e attr

### DIFF
--- a/sphere_56b/trunk/scripts/myt/itens_quests.scp
+++ b/sphere_56b/trunk/scripts/myt/itens_quests.scp
@@ -813,7 +813,7 @@ if (<src.npc>)
   link.more2=<src.uid>
  endif
 endif
-return 1
+return 0
 
 [ITEMDEF i_trig_guarded_door]
 ID=i_rune_glowing_2
@@ -855,7 +855,7 @@ if (<src.npc>)
   new.cont=<src.uid>
  endif
 endif
-return 1
+return 0
 
 [ITEMDEF i_key_quest]
 ID=01010
@@ -1274,7 +1274,7 @@ if (!<src.npc>) && (!<src.IsGM>) && (!<more1>)
  timer=<more2>
  more1=1
 endif
-return 1
+return 0
 
 on=@timer
 more1=0
@@ -2086,7 +2086,7 @@ if (!<argn1>) && (<src.npc>)    //Um NPC acabou de pisar
   tag.NPC=<src.UID>
  endif
 endif
-return 1
+return 0
 
 ON=@CLIENTTOOLTIP
 if (<src.isgm>)
@@ -3142,13 +3142,21 @@ SUBSECTION=Gatilhos
 DESCRIPTION=mecanismo discreto
 
 ON=@CREATE
+attr=090
 COLOR=0
-//Criacao automatica
+
 ON=@step
+if (!<src.npc>) && (!<src.IsGM>)
 link.say=@026 TRANK!
 link.nudgedown 20
 remove
-return 1
+return 0
+else
+src.sysmessagered CLICK! Faz a trava...
+return 0
+endif
+return 0
+
 
 //*****************************************************************************
 //Item: i_dismount
@@ -3345,6 +3353,7 @@ TYPE=t_normal
 
 
 ON=@CREATE
+attr=090
 COLOR=33
 src.sysmessage O movedor precisa de um Link e precisa ajustar tags.
 src.sysmessageyellow Ajuste a tag0.direcao1 para a direcao onde o link move.
@@ -3387,7 +3396,7 @@ endif
 return 0
     
 on=@step
-if (!<argn1>)&&!(<src.flags>&statf_dead)
+if (!<argn1>)&&(!<src.flags>&statf_dead)
     if (<morez>=2)||(<morez>=1)&&(!<src.npc>)
         if (<more2>>2)
             link.move <tag0.direcao1> <tag0.distancia1>
@@ -3434,7 +3443,7 @@ on=@Clienttooltip
 
 on=@step
 src.move <tag0.direcao> <tag0.distancia>
-return 1
+return 0
 
 //*****************************************************************************
 //Item: i_correnteza
@@ -3473,10 +3482,10 @@ if (<more1>==1)
             src.sysmessagered VOCE ESCORREGA E EH TRAGADO PELA CORRENTEZA!!!
             src.nudgedown 5
             src.emoteblue SPLATCH!
-            return 1
+            return 0
         endif
     endif
-return 1
+return 0
 
 //*****************************************************************************
 //Item: i_transportador
@@ -3511,7 +3520,7 @@ move <tag0.direcao>
 src.move <tag0.direcao>
 link.move <tag0.direcao>
 endif
-return 1
+return 0
 
 //aqui termina o extraido do itemforge. 388 linhas. 2017-10-22
 


### PR DESCRIPTION
Correção de Return 1 para Return 0 para permitir que players e mobs pisem sobre gerador de guarda de porta, guarda de container, gerador de spawn-on-touch, gerador de cartas, trava portas, empurrador, correnteza, transportador.

Correções de attr e outras menores.