### PR TITLE
Maces não Forjam mais

### DIFF
--- a/sphere_56b/trunk/scripts/myt/skill_armslore.scp
+++ b/sphere_56b/trunk/scripts/myt/skill_armslore.scp
@@ -890,7 +890,9 @@ tooltip_weapons
 return 1
 
 ON=@DCLICK
-IF (<src.IsNearType t_anvil,1>) || (<src.IsGM>)
+IF (!<id>==<0fb4>) // se não for martelo de ferreiro, equipa
+    src.act.equip
+ELIF (<src.IsNearType t_anvil,1>) || (<src.IsGM>)
     src.craft_loadLevel 1
 ELSE
     src.sysmessagered Voce presisa estar perto de uma bigorna.


### PR DESCRIPTION
Aos dois cliques em t_weapon_mac_smith, se não tiver o id de martelo de ferreiro, equipa.