### PR TITLE
Correção do event firemade

### DIFF
--- a/sphere_56b/trunk/scripts/myt/events_npc.scp
+++ b/sphere_56b/trunk/scripts/myt/events_npc.scp
@@ -821,13 +821,13 @@ ON=@Death
 // Create death explosion to damage those nearby.
 NEWITEM=i_fx_explode
 new.emotered explode
-act.TYPE=T_EXPLOSION
-act.ATTR=ATTR_MOVE_NEVER | ATTR_CAN_DECAY
-act.LINK=<uid>
-act.morex=10 // damage
-act.morey=090 // wFlags DAMAGE_GENERAL
-act.morez=4 // iDist
-act.p=<p>
+new.TYPE=T_EXPLOSION
+new.ATTR=ATTR_MOVE_NEVER | ATTR_CAN_DECAY
+new.LINK=<uid>
+new.morex=10 // damage
+new.morey=090 // wFlags DAMAGE_GENERAL
+new.morez=4 // iDist
+new.p=<p>
 new.TIMERD=5 // immediate decay
 SFX 011d
 remove

--- a/sphere_56b/trunk/scripts/myt/events_npc.scp
+++ b/sphere_56b/trunk/scripts/myt/events_npc.scp
@@ -831,7 +831,7 @@ act.p=<p>
 new.TIMERD=5 // immediate decay
 SFX 011d
 remove
-return 0
+return 1
 
 
 //*****************************************************************************

--- a/sphere_56b/trunk/scripts/myt/events_npc.scp
+++ b/sphere_56b/trunk/scripts/myt/events_npc.scp
@@ -828,7 +828,7 @@ act.morex=10 // damage
 act.morey=090 // wFlags DAMAGE_GENERAL
 act.morez=4 // iDist
 act.p=<p>
-act.TIMERD=5 // immediate decay
+new.TIMERD=5 // immediate decay
 SFX 011d
 remove
 return 0

--- a/sphere_56b/trunk/scripts/myt/events_npc.scp
+++ b/sphere_56b/trunk/scripts/myt/events_npc.scp
@@ -831,7 +831,7 @@ act.p=<p>
 act.TIMERD=5 // immediate decay
 SFX 011d
 remove
-return 1
+return 0
 
 
 //*****************************************************************************


### PR DESCRIPTION
Correção da linha 834 de return 1 para return 0, afim de que o flamstrike suma após a morte do NPC.