### PR TITLE
Adicionado o Golem Colossal

### DIFF
--- a/sphere_56b/trunk/scripts/myt/npcs.scp
+++ b/sphere_56b/trunk/scripts/myt/npcs.scp
@@ -7323,7 +7323,47 @@ ON=@NPCRESTOCK
 // Nível 10
 //*****************************************************************************
 //*****************************************************************************
-        
+
+[CHARDEF 033d]
+DEFNAME= c_golem_colossal
+NAME=Golem Colossal 
+// Sub-boss DG das Maquinas dos Anoes, no vulcao.
+ICON=i_pet_rising_colossus
+CAN=MT_WALK
+DESIRES=i_gold,e_notoriety
+RESOURCES=25 i_gears, 10 i_placa_ferro, 1  i_stone_rubi
+SOUND=snd_monster_rising_colossus
+TEVENTS=e_pvm
+TEVENTS=e_combat
+
+ARMOR=80
+DAM=30,35
+
+CATEGORY=Artificiais
+SUBSECTION=Nível 10
+DESCRIPTION=Golem Colossal
+ON=@Create
+   NPC=brain_monster
+   FAME=0
+   KARMA=0
+   STR={190 200}
+   MAXHITS={1500 2000}
+   DEX={30 50}
+   MAXSTAM={20 40}
+   INT={5 10}
+   MAGICRESISTANCE={100.0 125.0}
+   WRESTLING={95.0 105.0}
+   RESPHYSICAL={0 10}
+   RESCOLD={45 55}
+   RESENERGY={0 10}
+   RESFIRE={45 55}
+   RESPOISON={55 65}
+   f_npc_spawn
+   npc_aggravate dam_energy|dam_slash
+   npc_dodger dam_pierce|dam_poison
+
+ON=@NPCRESTOCK
+
 //*****************************************************************************
 // c_dragon_green
 //*****************************************************************************


### PR DESCRIPTION
- Adicionado MOB Golem Colossal, sub-boss da DG das máquinas dos anões. Linha 7327.
MOB classificado como lvl 10, categoria Artificiais.