### PR TITLE
Correção de drop de arma do G. Ofidiano

### DIFF
--- a/sphere_56b/trunk/scripts/myt/npcs.scp
+++ b/sphere_56b/trunk/scripts/myt/npcs.scp
@@ -16819,7 +16819,7 @@ SPEECHCOLOR colors_brown
 
 
 ON=@NPCRESTOCK
-ITEM=i_bardiche
+ITEM=i_bardich
 ITEM=i_pocao_ajuda,2
 
             


### PR DESCRIPTION
Erro na grafia do item bardiche.
O  correto do MyT é sem a letra "e", portanto i_bardich. Com a letra "e" ele chama o item custom do UO.