### PR TITLE
Adicionando Projetos de Furtivas para Loot

### DIFF
--- a/sphere_56b/trunk/scripts/myt/templates_myt.scp
+++ b/sphere_56b/trunk/scripts/myt/templates_myt.scp
@@ -868,7 +868,14 @@ SUBSECTION=templates
 DESCRIPTION=Random loot receitas
 CONTAINER=i_bag
 NAME=saco
-ITEM={ I_LOOT_recipe_carpentry 1 I_LOOT_recipe_tinker 1 I_LOOT_recipe_cooking 1 I_LOOT_recipe_alchemy 1 I_LOOT_recipe_blacksmithing 1 }
+ITEM={ I_LOOT_recipe_carpentry 1 I_LOOT_recipe_tinker 1 I_LOOT_recipe_cooking 1 I_LOOT_recipe_alchemy 1 I_LOOT_recipe_blacksmithing 1 I_LOOT_recipe_furtiva 1 }
+
+[TEMPLATE I_LOOT_recipe_furtiva]
+DEFNAME=random_recipe_furtiva
+CATEGORY=MyT - Item Templates
+SUBSECTION=templates
+DESCRIPTION=Random receitas roupas furtivas
+ITEM={ i_recipe_braco_furtiva 1 i_recipe_cabeca_furtiva 1 i_recipe_luva_furtiva 1 i_recipe_peito_furtiva 1 i_recipe_perna_furtiva 1 i_recipe_pescoco_furtiva 1 }
 
 [TEMPLATE i_random_plaster]
 CATEGORY=MyT - Item Templates


### PR DESCRIPTION
Adicionando projetos de roupas furtivas i_recipe_braco_furtiva, i_recipe_cabeca_furtiva, i_recipe_luva_furtiva, i_recipe_peito_furtiva, i_recipe_perna_furtiva, i_recipe_pescoco_furtiva para poderem aparecer no Loot.