### PR TITLE
Acerto de possivel duplicidade em ID de masc veado

### DIFF
--- a/sphere_56b/trunk/scripts/myt/itens_tailor.scp
+++ b/sphere_56b/trunk/scripts/myt/itens_tailor.scp
@@ -1696,7 +1696,7 @@ HITPOINTS=<MAXHITS>
 // 01547
 //*****************************************************************************
 [ITEMDEF 01547]
-DEFNAME=i_mask_deer
+DEFNAME=i_mascara_veado
 NAME=Mascara de Veado
 TYPE=t_clothing
 RESOURCES=1 i_thread, 2 i_cloth, 1 i_veado_cabeca


### PR DESCRIPTION
Acerto no ID da máscara de veado que possivelmente esta em conflito com o item padrão do UO.
Linha 1699.