### PR TITLE
Correção da mascara de veado.

### DIFF
--- a/sphere_56b/trunk/scripts/myt/itens_tailor.scp
+++ b/sphere_56b/trunk/scripts/myt/itens_tailor.scp
@@ -1679,6 +1679,7 @@ SKILLMAKE=TAILORING 85.0
 VALUE=126
 DYE=1
 REQSTR=5
+ARMOR=5
 WEIGHT=6
 TDATA4=30
 DUPELIST=01546
@@ -1690,7 +1691,10 @@ DESCRIPTION=Mascara de Urso
 ON=@CREATE
 MAXHITS={21 23}
 HITPOINTS=<MAXHITS>
-
+   morex=3
+   morey=8
+   morez=4
+   morem=4
 
 //*****************************************************************************
 // i_mascara_veado
@@ -1704,6 +1708,7 @@ SKILLMAKE=TAILORING 80.0
 VALUE=94
 DYE=1
 REQSTR=5
+ARMOR=2
 WEIGHT=6
 TDATA4=30
 DUPELIST=01548
@@ -1711,11 +1716,13 @@ CATEGORY=MyT - Provisions - Clothes
 SUBSECTION=chapeus
 DESCRIPTION=Mascara de Veado
 
-
 ON=@CREATE
 MAXHITS={21 23}
 HITPOINTS=<MAXHITS>
-
+   morex=6
+   morey=8
+   morez=1
+   morem=7
 
 //*****************************************************************************
 // 01549

--- a/sphere_56b/trunk/scripts/myt/itens_tailor.scp
+++ b/sphere_56b/trunk/scripts/myt/itens_tailor.scp
@@ -1693,10 +1693,10 @@ HITPOINTS=<MAXHITS>
 
 
 //*****************************************************************************
-// 01547
+// i_mascara_veado
 //*****************************************************************************
-[ITEMDEF 01547]
-DEFNAME=i_mascara_veado
+[ITEMDEF i_mascara_veado]
+ID=i_mask_deer
 NAME=Mascara de Veado
 TYPE=t_clothing
 RESOURCES=1 i_thread, 2 i_cloth, 1 i_veado_cabeca


### PR DESCRIPTION
Trocado de DEFNAME para ID tendo em vista que ele puxa do script padrão do sphere o item máscara de veado fazendo o custom do shard.
Desta maneira não há conflito sobrepondo os itens.
A partir da linha 1696.
Script padrão de referência:
https://github.com/vinicius-arroyo/myt-shard/blob/sphere_56d/sphere_56b/trunk/scripts/items/sphere_item_provisions_clothing.scp
Linha 405.