### PR TITLE
Alteração de regions preliminar

### DIFF
--- a/sphere_56b/trunk/scripts/myt/special/mapa.scp
+++ b/sphere_56b/trunk/scripts/myt/special/mapa.scp
@@ -137,10 +137,10 @@ NAME=Porto Vila
 GROUP=Cidades
 TAG.modtemp=20
 P=1025,2429,0,0
-RECT=1046,2350,1139,2369,0
-RECT=1014,2360,1055,2460,0
-RECT=1055,2370,1115,2438,0
-RECT=1115,2390,1150,2430,0
+RECT=1055,2338,1139,2369,0
+RECT=995,2338,1055,2460,0
+RECT=1055,2370,1139,2432,0
+RECT=5300,3175,5352,3230,0
 FLAGS=00000
 EVENTS=r_default_water, r_default_tree, r_default_grass, r_portovila_rock, r_snd_city
 
@@ -150,7 +150,7 @@ NAME=Livre Comercio
 GROUP=Cidades
 TAG.modtemp=20
 P=1034,2287,0,0
-RECT=965,2133,1039,2349,0
+RECT=952,2200,1072,2304,0
 FLAGS=00000
 EVENTS=r_default_water, r_default_tree, r_default_grass, r_mina_ini
 
@@ -306,14 +306,6 @@ RECT=5644,517,5791,611,0
 FLAGS=region_flag_underground
 EVENTS=r_mina_ini
 
-[AREADEF a_mina_belaryar]
-NAME=Mina de Belaryar
-GROUPS=Regioes Naturais
-P=5314,3199,0,0
-RECT=5300,3175,5352,3230
-FLAGS=region_flag_underground
-EVENTS=r_mina_ini, r_snd_dungeon
-
 [AREADEF a_mina_vila_belaryar]
 NAME=Mina da Vila de Belaryar
 GROUPS=Regioes Naturais
@@ -467,8 +459,9 @@ GROUP=Regioes Naturais
 P=770,2460,0,0
 RECT=605,2227,814,2505,0
 RECT=750,2505,814,2575,0
-RECT=814,2338,1014,2591,0
+RECT=814,2338,995,2591,0
 RECT=946,2591,986,2630,0
+RECT=995,2460,1035,2548,0
 FLAGS=00000
 EVENTS=r_default_water, r_logsul, r_default_grass, r_mpobre_rock
 


### PR DESCRIPTION
- Alteração de regions do entorno de Porto Vila para adaptar as mudanças de mapa do dia 23/04/2018.
Ajustado Porto Vila, Moloj Gul e Livre Comércio.
(Faltam alterações na parte sul - region Gul - do mapa conforme solicitado)