### PR TITLE
Ajuste mínimo em Inscription

### DIFF
--- a/sphere_56b/trunk/scripts/myt/events.scp
+++ b/sphere_56b/trunk/scripts/myt/events.scp
@@ -1179,7 +1179,7 @@ IF (!<IsGM>)
 //   serv.log sabe a spell
    argn2=(<strarg <serv.spell.<argn1>.skillreq>>*100)/125                         //Bônus de 25%
   elif (<inscription> > <local.skill>)   //Não sabe a magia. Usar Inscription?
-   if (<skillcheck inscription <eval <strarg <serv.spell.<argn1>.skillreq>>/10>>)
+   if (<src.skillcheck inscription <eval <strarg <serv.spell.<argn1>.skillreq>>/10>>)
     argn2=0      //Passou no teste com inscription
    else
     argn2=1500   //Não passou no teste de inscription


### PR DESCRIPTION
Por comparação, a função skillcheck, raramente usada, mas quando usada há um reference. 99% de chance de nada mudar, mas apostemos no 1% vagabundo.
A skill não está funcionando com plevel 0, ainda que funcione com plevel 4 com .gm off.