### PR TITLE
Impedir a Fuga das Galinhas

### DIFF
--- a/sphere_56b/trunk/scripts/myt/spells_myt.scp
+++ b/sphere_56b/trunk/scripts/myt/spells_myt.scp
@@ -1313,7 +1313,7 @@ RETURN 1
 voltar
 
 [FUNCTION voltar]
-if (<src.body> == c_snake) || (<src.color> == 0b53)
+if (<src.body> == c_snake) || (<src.color> == 0b53) || (<src.body> == c_chicken)
 	sysmessagered Você faz muita forçar para voltar a sua forma natural, mas não consegue.
 	peidar
 	return 1


### PR DESCRIPTION
A poção de transformação em galinha estava sendo contornada com .voltar
c_chiken no teste da linha 1316 que verifica se não é malandragem.