### PR TITLE
Ajuste mínimo Manuel Bandeira

### DIFF
--- a/sphere_56b/trunk/scripts/myt/sistema_de_catalisadores.scp
+++ b/sphere_56b/trunk/scripts/myt/sistema_de_catalisadores.scp
@@ -260,7 +260,7 @@ on=@dclick
 SRC.message *abriu o saco* 
 SRC.NEWITEM=I_SACO_carvao2
 SRC.ACT.BOUNCE 
-REMOVE 
+SRC.CONSUME 1 i_saco_carvao
 RETURN 1 
 
 


### PR DESCRIPTION
É o mesmo ajuste feito com o saco de farinha no Ajuste Anti-Maradona: se o saco dclickado estivesse amounted, era tudo removido, agora só 1 é consumido na pilha.
Referência: Poema Meninos Carvoeiros.