### PR TITLE
Ajuste de atualização de Trigger no Sphere

### DIFF
--- a/sphere_56b/trunk/scripts/myt/sistema_de_quests.scp
+++ b/sphere_56b/trunk/scripts/myt/sistema_de_quests.scp
@@ -122,9 +122,9 @@ endif
 
 forcont <SRC> 0
     if ( <baseid>==i_quest_system )
-//      SRC.SYSMESSAGE LOOP <morex> <SRC.ACT.baseid> <tag.param1>
+//      SRC.SYSMESSAGE LOOP <morex> <SRC.ARGO.baseid> <tag.param1>
         if ( <morex> == quest_type_kill_mob ) 
-            if ( <SRC.ACT.baseid>==<tag.param1> )
+            if ( <SRC.ARGO.baseid>==<tag.param1> )
                 quest_updateKillMobQuest <uid>
             endif
         endif
@@ -215,7 +215,7 @@ if ( <OBJ.amount> > 0 )
     OBJ.amount -= 1
 
     //salve nome
-    LOCAL.killed=<SRC.ACT.name>
+    LOCAL.killed=<SRC.ARGO.name>
     
     if !(strmatch(<serv.itemdef.<OBJ.tag.param2>.name>,0))
         SRC.NEWITEM <tag.param2>
@@ -627,11 +627,11 @@ return 1
 //esta funcao eh chamada qndo o player aperta o botao "quest" do paperdoll
 [FUNCTION quest_userQuests]
 //menu m_quest_button
-if (<src.IsGM>) && (!<argv>)	//Se for GM, chama menu de GM. Se <argn>, est· vindo do menu de GM. Abre o dialog normal de player.
+if (<src.IsGM>) && (!<argv>)	//Se for GM, chama menu de GM. Se <argn>, est√° vindo do menu de GM. Abre o dialog normal de player.
 	menu m_quest
 	return 1
 endif
-src.ctag.quest_selectedNpc=0	//ForÁa que n„o h· NPC neste processo.
+src.ctag.quest_selectedNpc=0	//For√ßa que n√£o h√° NPC neste processo.
 quest_closeDialogs
 quest_createPlayerQuestList
 dialog d_quest_list 
@@ -656,21 +656,21 @@ return 1
 //*****************************************************************************
 //Seta ou reseta um NPC como quest giver
 [FUNCTION quest_setQuestNPC]
-//Se n„o h· argumento, abrir target.
+//Se n√£o h√° argumento, abrir target.
 if (!<argo>)
 	sysmessageyellow Selecione o NPC:
 	targetf quest_setQuestNPC
 	return 0
 endif
 
-//Se o argumento n„o È char, cancele.
+//Se o argumento n√£o √© char, cancele.
 if (<IsEmpty <argo.brain>>) || (<argo.brain>==0)
 	sysmessagered O alvo nao eh um NPC.
 	MENU m_quest
 	return 0
 endif
 
-//Testa se o NPC j· tem os events
+//Testa se o NPC j√° tem os events
 if (STRMATCH(*e_quest_npc*,<argo.events>))
 	argo.events=-e_quest_npc
 	argo.speech=-jobQUEST_SYSTEM
@@ -681,7 +681,7 @@ if (STRMATCH(*e_quest_npc*,<argo.events>))
 else
 	argo.events=+e_quest_npc
 	serv.log [QUEST] Instalando event e_quest_npc em <argo.name> (<argo>) - P:<tag.name> (ACC:<account>)
-	//N„o instalar em vendor, senescal, guarda e porteiro
+	//N√£o instalar em vendor, senescal, guarda e porteiro
 	if !(<argo.tag0.vendor_type>) && !(STRMATCH(*e_town_guard*,<argo.tevents>)) && !(STRMATCH(*e_town_gatekeeper*,<argo.tevents>)) && !(STRMATCH(*e_town_seneschal*,<argo.tevents>))
 		argo.speech=+jobQUEST_SYSTEM
 		serv.log [QUEST] Instalando speech jobQUEST_SYSTEM em <argo.name> (<argo>) - P:<tag.name> (ACC:<account>)
@@ -699,21 +699,21 @@ endif
 //*****************************************************************************
 //Gerencia as quests de um NPC
 [FUNCTION quest_manageQuestNPC]
-//Se n„o h· argumento, abrir target.
+//Se n√£o h√° argumento, abrir target.
 if (!<argo>)
 	sysmessageyellow Selecione o NPC:
 	targetf quest_manageQuestNPC
 	return 0
 endif
 
-//Se o argumento n„o È char, cancele.
+//Se o argumento n√£o √© char, cancele.
 if (<IsEmpty <argo.brain>>) || (<argo.brain>==0)
 	sysmessagered O alvo nao eh um NPC.
 	MENU m_quest
 	return 0
 endif
 
-//Testar se esse NPC È quester
+//Testar se esse NPC √© quester
 if !(STRMATCH(*e_quest_npc*,<argo.events>))
 	sysmessagered Esse NPC nao dah quests.
 	MENU m_quest
@@ -731,7 +731,7 @@ dialog d_quest_list
 //*****************************************************************************
 [FUNCTION quest_targCleanupPC]
 //Apaga todos os registros de quests de um jogador
-//Se n„o h· argumento, abrir target.
+//Se n√£o h√° argumento, abrir target.
 if (<account.plevel> < 4)
 	sysmessage Voce nao tem privilegio para isso.
 	MENU m_quest
@@ -743,7 +743,7 @@ if (!<argo>)
 	return 0
 endif
 
-//Se o argumento n„o È char, cancele.
+//Se o argumento n√£o √© char, cancele.
 if (<IsEmpty <argo.brain>>) || (<argo.brain> > 0)
 	sysmessagered O alvo nao eh um jogador.
 	MENU m_quest
@@ -1055,13 +1055,13 @@ on=0 Custom step (depende de script)
 100, 100
 quest_drawGumps
 if (!<SRC.CTAG0.quest_listType>)
-	if (!<SRC.CTAG0.quest_selectedNpc>)	//N„o permitir trocar terminadas/atuais se for um dialog de NPC para pegar quests novas. Somente via bot„o.
+	if (!<SRC.CTAG0.quest_selectedNpc>)	//N√£o permitir trocar terminadas/atuais se for um dialog de NPC para pegar quests novas. Somente via bot√£o.
 		dtext 320 45 1152 Ver terminadas
 		button 420 42 9720 9722 1 0 5	//Ver quests antigas
 	endif
 	dtext 150 60 1152 Quests ativas
 else
-	if (!<SRC.CTAG0.quest_selectedNpc>)	//N„o permitir trocar terminadas/atuais se for um dialog de NPC para pegar quests novas. Somente via bot„o.
+	if (!<SRC.CTAG0.quest_selectedNpc>)	//N√£o permitir trocar terminadas/atuais se for um dialog de NPC para pegar quests novas. Somente via bot√£o.
 		dtext 320 45 1152 Ver ativas
 		button 420 42 9723 9722 1 0 6	//Ver quests antigas
 	endif
@@ -1206,7 +1206,7 @@ if ( <DB.ROW.NUMROWS> > 0 )
 else
     button 192 435 12018 12019 1 0 3    //Refuse button
 endif
-if (<src.ctag0.quest_selectedNpc>)  //Tem NPC envolvido? N„o faz sentido REFUSE na lista de quests antigas ou ativa.
+if (<src.ctag0.quest_selectedNpc>)  //Tem NPC envolvido? N√£o faz sentido REFUSE na lista de quests antigas ou ativa.
 	button 282 435 12000 12001 1 0 2    //Accept button
 endif
 


### PR DESCRIPTION
No Trigger @Kill do Sphere, o que era referenciado como ACT, agora é ARGO.
Da maneira que estava, o sistema não reconhecia que o Player matou o mob certo.
Troquei mesmo na linha // fria, just in case.