### PR TITLE
Braceletes Inquebraveis e Correção Mínima

### DIFF
--- a/sphere_56b/trunk/scripts/myt/sistema_de_combate.scp
+++ b/sphere_56b/trunk/scripts/myt/sistema_de_combate.scp
@@ -759,7 +759,7 @@ if <R1000> > <LOCAL.p>
     return 0
 endif
 
-I.emoteyellow Apara
+src.emoteyellow Apara
 
 if !<npc>
     sysmessageyellow <src.name> apara seu golpe!
@@ -1075,7 +1075,7 @@ if !<SRC.NPC>
         END
         BEGIN
             cmb_damageSrcArmor layer_gloves,<argn1>
-            cmb_damageSrcCloth layer_wrist,<argn1>
+//            cmb_damageSrcCloth layer_wrist,<argn1> //braceletes e layer 14 tornam-se inquebráveis
         END
         BEGIN
             cmb_damageSrcArmor layer_pants,<argn1>


### PR DESCRIPTION
Braceletes e Itens de Layer 14 tornam-se inquebráveis, não recebem mais dano.
Ajuste de erro de sintaxe antigo, que fazia com que o atacante soltasse emote *apara* ao invés de quem de fato está aparando.