### PR TITLE
Correção contra absusos

### DIFF
--- a/sphere_56b/trunk/scripts/myt/spells_focus.scp
+++ b/sphere_56b/trunk/scripts/myt/spells_focus.scp
@@ -1139,21 +1139,26 @@ ID=i_gold
 type=t_script
 
 on=@timer
-if (<more1>)
-link.effect 1 0
-link.sfx 05CE
-link.damage <more2>,dam_energy,<tag0.caster>
+if (<link.flags>&statf_indoors) || (<region.flags>&region_flag_underground) //se o alvo estiver em lugar coberto.
+	link.sysmessagered seus pelos se arrepiam em energia estatica estatica
+
 else
-obj=<UID>
-forchars 5
-newitem <obj.defname>
-new.p=<p>
-new.more2=<R<eval <obj.more2>/2>,<obj.more2>>
-new.more1=1
-new.link=<UID>
-new.tag.caster=<obj.tag.caster>
-new.timerd=<R3,25>
-end
+	if (<more1>)
+		link.effect 1 0
+		link.sfx 05CE
+		link.damage <more2>,dam_energy,<tag0.caster>
+	else
+		obj=<UID>
+		forchars 5
+			newitem <obj.defname>
+			new.p=<p>
+			new.more2=<R<eval <obj.more2>/2>,<obj.more2>>
+			new.more1=1
+			new.link=<UID>
+			new.tag.caster=<obj.tag.caster>
+			new.timerd=<R3,25>
+		end
+	endif
 endif
 remove
 return 1


### PR DESCRIPTION
Player ficavam no lado de fora de builds e sapecavam os mobs de relâmpagos. Depois passeavam colhendo o loot.